### PR TITLE
Total overhaul, now works as expected on real TCP connections

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -23,7 +23,7 @@ type mpConn struct {
 }
 
 func newMPConn(cid connectionID) *mpConn {
-	return &mpConn{cid: cid,
+	mpc := &mpConn{cid: cid,
 		lastFN:           minFrameNumber - 1,
 		recvQueue:        newReceiveQueue(recieveQueueLength),
 		writerMaybeReady: make(chan bool, 1),
@@ -31,6 +31,8 @@ func newMPConn(cid connectionID) *mpConn {
 		pendingAckMap:    make(map[uint64]*pendingAck),
 		pendingAckMu:     &sync.RWMutex{},
 	}
+	go mpc.retransmitLoop()
+	return mpc
 }
 func (bc *mpConn) Read(b []byte) (n int, err error) {
 	return bc.recvQueue.read(b)

--- a/conn.go
+++ b/conn.go
@@ -15,12 +15,17 @@ type mpConn struct {
 	muSubflows sync.RWMutex
 	recvQueue  *receiveQueue
 	closed     uint32 // 1 == true, 0 == false
+
+	pendingAckMap map[uint64]*pendingAck
+	pendingAckMu  *sync.RWMutex
 }
 
 func newMPConn(cid connectionID) *mpConn {
 	return &mpConn{cid: cid,
-		lastFN:    minFrameNumber - 1,
-		recvQueue: newReceiveQueue(recieveQueueLength),
+		lastFN:        minFrameNumber - 1,
+		recvQueue:     newReceiveQueue(recieveQueueLength),
+		pendingAckMap: make(map[uint64]*pendingAck),
+		pendingAckMu:  &sync.RWMutex{},
 	}
 }
 func (bc *mpConn) Read(b []byte) (n int, err error) {

--- a/conn.go
+++ b/conn.go
@@ -28,8 +28,18 @@ func (bc *mpConn) Read(b []byte) (n int, err error) {
 }
 
 func (bc *mpConn) Write(b []byte) (n int, err error) {
+	frame := composeFrame(atomic.AddUint64(&bc.lastFN, 1), b)
+
 	for _, sf := range bc.sortedSubflows() {
-		sf.sendQueue <- composeFrame(atomic.AddUint64(&bc.lastFN, 1), b)
+		select {
+		case sf.sendQueue <- frame:
+			return len(b), nil
+		default:
+		}
+	}
+
+	for _, sf := range bc.sortedSubflows() {
+		sf.sendQueue <- frame
 		return len(b), nil
 	}
 	return 0, ErrClosed

--- a/multipath.go
+++ b/multipath.go
@@ -82,7 +82,8 @@ var (
 )
 
 type connectionID uuid.UUID
-type frame struct {
+
+type rxFrame struct {
 	fn    uint64
 	bytes []byte
 }

--- a/multipath.go
+++ b/multipath.go
@@ -123,8 +123,6 @@ func (f *sendFrame) isDataFrame() bool {
 func (f *sendFrame) release() {
 	if atomic.CompareAndSwapInt32(f.released, 0, 1) {
 		pool.Put(f.buf)
-	} else {
-		log.Error("Release already released buffer!")
 	}
 }
 

--- a/multipath.go
+++ b/multipath.go
@@ -87,12 +87,18 @@ type frame struct {
 	bytes []byte
 }
 
+type transmissionDatapoint struct {
+	sf     *subflow
+	txTime time.Time
+}
+
 type sendFrame struct {
 	fn                 uint64
 	sz                 uint64
 	buf                []byte
 	released           *int32 // 1 == true; 0 == false. Use pointer so copied object still references the same address, as buf does
 	retransmissions    int
+	sentVia            []transmissionDatapoint // Contains the subflows it's already been written to, and when
 	beingRetransmitted uint64
 }
 

--- a/multipath.go
+++ b/multipath.go
@@ -88,11 +88,12 @@ type frame struct {
 }
 
 type sendFrame struct {
-	fn              uint64
-	sz              uint64
-	buf             []byte
-	released        *int32 // 1 == true; 0 == false. Use pointer so copied object still references the same address, as buf does
-	retransmissions int
+	fn                 uint64
+	sz                 uint64
+	buf                []byte
+	released           *int32 // 1 == true; 0 == false. Use pointer so copied object still references the same address, as buf does
+	retransmissions    int
+	beingRetransmitted uint64
 }
 
 func composeFrame(fn uint64, b []byte) *sendFrame {

--- a/receivequeue.go
+++ b/receivequeue.go
@@ -33,7 +33,7 @@ func newReceiveQueue(size int) *receiveQueue {
 		buf:                   make([]rxFrame, size),
 		size:                  uint64(size),
 		rp:                    minFrameNumber % uint64(size), // frame number starts with minFrameNumber, so should the read pointer
-		availableFrameChannel: make(chan bool),
+		availableFrameChannel: make(chan bool, 1),
 		readNotifyChannel:     make(chan bool),
 		readLockmaybeidk:      &sync.Mutex{},
 	}
@@ -109,6 +109,10 @@ func (rq *receiveQueue) isFull() bool {
 			if printFull {
 				log.Tracef("receiveQueue is %d%% full! (%d/%d)", int((float32(i) / float32(rq.size) * 100)), i, rq.size)
 			}
+			return false
+		}
+
+		if rq.buf[idx].bytes == nil {
 			return false
 		}
 

--- a/receivequeue.go
+++ b/receivequeue.go
@@ -81,7 +81,7 @@ func (rq *receiveQueue) add(f *rxFrame, sf *subflow) {
 		}
 	}
 
-	if f.fn > readFrameTip+rq.size {
+	if f.fn > readFrameTip+rq.size && readFrameTip != 0 {
 		log.Debugf("Near corruption incident?? %v vs the max peek of %v (frametip %d)", f.fn, readFrameTip+rq.size-1, readFrameTip)
 		return // Nope! this will corrupt the buffer
 	}

--- a/receivequeue.go
+++ b/receivequeue.go
@@ -18,68 +18,135 @@ type receiveQueue struct {
 	size uint64
 	// rp stands for read pointer, point to the index of the frame containing
 	// data yet to be read.
-	rp             uint64
-	availableFrame *sync.Cond
-	availableSlot  *sync.Cond
-	readDeadline   time.Time
-	closed         uint32 // 1 == true, 0 == false
+	rp                    uint64
+	availableFrameChannel chan bool
+	readNotifyChannel     chan bool
+	readDeadline          time.Time
+	deadlineLock          sync.Mutex
+	closed                uint32 // 1 == true, 0 == false
+	readFrameTip          uint64
+	readLockmaybeidk      *sync.Mutex
 }
 
 func newReceiveQueue(size int) *receiveQueue {
 	rq := &receiveQueue{
-		buf:            make([]frame, size),
-		size:           uint64(size),
-		rp:             minFrameNumber % uint64(size), // frame number starts with minFrameNumber, so should the read pointer
-		availableFrame: sync.NewCond(&sync.Mutex{}),
-		availableSlot:  sync.NewCond(&sync.Mutex{}),
+		buf:                   make([]frame, size),
+		size:                  uint64(size),
+		rp:                    minFrameNumber % uint64(size), // frame number starts with minFrameNumber, so should the read pointer
+		availableFrameChannel: make(chan bool),
+		readNotifyChannel:     make(chan bool),
+		readLockmaybeidk:      &sync.Mutex{},
 	}
 	return rq
 }
 
-func (rq *receiveQueue) add(f *frame) {
-	for {
-		if rq.tryAdd(f) {
-			return
+func (rq *receiveQueue) add(f *frame, sf *subflow) {
+
+	select {
+	case rq.availableFrameChannel <- true:
+	default:
+	}
+	// Another thing to protect against, is that we might be
+	// locally blocked on a full receiveQueue. If that is the
+	// case then we don't want to return instantly from this
+	// function since that will just case retransmits to fire
+	// over and over again, causing mass bandwidth loss.
+	// Instead let's quickly check if we have all of the data we need
+	// to read, and if we do, hang until we don't have that problem anymore
+	if rq.isFull() {
+		for {
+			var abort bool
+			select {
+			case <-rq.readNotifyChannel:
+				if !rq.isFull() {
+					abort = true
+					break
+				}
+			}
+			if abort {
+				break
+			}
 		}
-		if !rq.waitForSlot() {
-			pool.Put(f.bytes)
+	}
+	select {
+	case rq.availableFrameChannel <- true:
+	default:
+	}
+
+	readFrameTip := atomic.LoadUint64(&rq.readFrameTip)
+
+	if readFrameTip != 0 {
+		if readFrameTip > f.fn || readFrameTip == f.fn {
+			sf.ack(f.fn)
 			return
 		}
 	}
+
+	if f.fn > readFrameTip+rq.size {
+		log.Debugf("Near corruption incident?? %v vs the max peek of %v (frametip %d)", f.fn, readFrameTip+rq.size-1, readFrameTip)
+		return // Nope! this will corrupt the buffer
+	}
+
+	if rq.tryAdd(f) {
+		sf.ack(f.fn)
+		return
+	}
+
+	// Protect against the socket being closed
+	if atomic.LoadUint32(&rq.closed) == 1 {
+		pool.Put(f.bytes)
+		return
+	}
+
+}
+
+func (rq *receiveQueue) isFull() bool {
+	printFull := false
+	for i := uint64(0); i < rq.size; i++ {
+		expectedFrameNumber := rq.readFrameTip + i
+		idx := expectedFrameNumber % rq.size
+
+		if rq.buf[idx].fn != expectedFrameNumber {
+			if printFull {
+				log.Tracef("receiveQueue is %d%% full! (%d/%d)", int((float32(i) / float32(rq.size) * 100)), i, rq.size)
+			}
+			return false
+		}
+
+		if i == rq.size/2 {
+			printFull = true
+		}
+	}
+
+	return true
 }
 
 func (rq *receiveQueue) tryAdd(f *frame) bool {
 	idx := f.fn % rq.size
-	rq.availableFrame.L.Lock()
-	defer rq.availableFrame.L.Unlock()
 	if rq.buf[idx].bytes == nil {
 		// empty slot
 		rq.buf[idx] = *f
 		if idx == rq.rp {
-			rq.availableFrame.Signal()
+			select {
+			case rq.availableFrameChannel <- true:
+			default:
+			}
 		}
 		return true
 	} else if rq.buf[idx].fn == f.fn {
 		// retransmission, ignore
+		log.Tracef("Got a retransmit. for %d", f.fn)
 		pool.Put(f.bytes)
 		return true
+	}
+
+	if idx != 0 {
+		log.Tracef("Not what I was looking for, I'm looking for frame %v", rq.buf[idx-1].fn+1)
 	}
 	return false
 }
 
-func (rq *receiveQueue) waitForSlot() bool {
-	rq.availableSlot.L.Lock()
-	rq.availableSlot.Wait()
-	rq.availableSlot.L.Unlock()
-	if atomic.LoadUint32(&rq.closed) == 1 {
-		return false
-	}
-	return true
-}
-
 func (rq *receiveQueue) read(b []byte) (int, error) {
-	rq.availableFrame.L.Lock()
-	defer rq.availableFrame.L.Unlock()
 	for {
 		if rq.buf[rq.rp].bytes != nil {
 			break
@@ -90,13 +157,34 @@ func (rq *receiveQueue) read(b []byte) (int, error) {
 		if rq.dlExceeded() {
 			return 0, context.DeadlineExceeded
 		}
-		rq.availableFrame.Wait()
+
+		select {
+		case rq.readNotifyChannel <- true:
+		default:
+		}
+		<-rq.availableFrameChannel
 	}
+
+	rq.readLockmaybeidk.Lock()
+	defer rq.readLockmaybeidk.Unlock()
+
 	totalN := 0
 	cur := rq.buf[rq.rp].bytes
 	for cur != nil && totalN < len(b) {
+		oldFrameTip := atomic.LoadUint64(&rq.readFrameTip)
+		if (rq.buf[rq.rp].fn != oldFrameTip+1) && (rq.buf[rq.rp].fn != oldFrameTip) && oldFrameTip != 0 {
+			log.Errorf("receiveQueue buffer corruption detected [%v vs %v] (The crash happened at idx = %d)", rq.buf[rq.rp].fn, oldFrameTip+1, rq.rp)
+			log.Tracef("All Buffers: ")
+			for idx, v := range rq.buf {
+				log.Tracef("\t[%d]fn %d, [%d]byte\n", idx, v.fn, len(v.bytes))
+			}
+			rq.close()
+			return 0, ErrClosed
+		}
 		n := copy(b[totalN:], cur)
 		if n == len(cur) {
+			log.Tracef("Finished with read frame %d\n", rq.buf[rq.rp].fn)
+			atomic.StoreUint64(&rq.readFrameTip, rq.buf[rq.rp].fn)
 			pool.Put(cur)
 			rq.buf[rq.rp].bytes = nil
 			rq.rp = (rq.rp + 1) % rq.size
@@ -104,24 +192,42 @@ func (rq *receiveQueue) read(b []byte) (int, error) {
 			// The frames in the ring buffer are never overridden, so we can
 			// safely update the bytes to reflect the next read position.
 			rq.buf[rq.rp].bytes = cur[n:]
+			log.Tracef("Partial read frame %d\n", rq.buf[rq.rp].fn)
 		}
 		totalN += n
 		cur = rq.buf[rq.rp].bytes
 	}
-	rq.availableSlot.Signal()
+
+	select {
+	case rq.readNotifyChannel <- true:
+	default:
+	}
+
 	return totalN, nil
 }
 
 func (rq *receiveQueue) setReadDeadline(dl time.Time) {
-	rq.availableFrame.L.Lock()
+	rq.deadlineLock.Lock()
 	rq.readDeadline = dl
-	rq.availableFrame.L.Unlock()
+	rq.deadlineLock.Unlock()
 	if !dl.IsZero() {
 		ttl := dl.Sub(time.Now())
 		if ttl <= 0 {
-			rq.availableFrame.Broadcast()
+			for {
+				abort := false
+				select {
+				case rq.availableFrameChannel <- true:
+				default:
+					abort = true
+				}
+				if abort {
+					break
+				}
+			}
 		} else {
-			time.AfterFunc(ttl, rq.availableFrame.Broadcast)
+			time.AfterFunc(ttl, func() {
+				rq.availableFrameChannel <- true
+			})
 		}
 	}
 }
@@ -132,6 +238,15 @@ func (rq *receiveQueue) dlExceeded() bool {
 
 func (rq *receiveQueue) close() {
 	atomic.StoreUint32(&rq.closed, 1)
-	rq.availableFrame.Broadcast()
-	rq.availableSlot.Broadcast()
+	abort := false
+	for {
+		select {
+		case rq.availableFrameChannel <- true:
+		default:
+			abort = true
+		}
+		if abort {
+			break
+		}
+	}
 }

--- a/receivequeue.go
+++ b/receivequeue.go
@@ -14,7 +14,7 @@ import (
 // that the frame number is sequential, so when a new frame arrives, it is
 // placed at buf[frameNumber % size].
 type receiveQueue struct {
-	buf  []frame
+	buf  []rxFrame
 	size uint64
 	// rp stands for read pointer, point to the index of the frame containing
 	// data yet to be read.
@@ -30,7 +30,7 @@ type receiveQueue struct {
 
 func newReceiveQueue(size int) *receiveQueue {
 	rq := &receiveQueue{
-		buf:                   make([]frame, size),
+		buf:                   make([]rxFrame, size),
 		size:                  uint64(size),
 		rp:                    minFrameNumber % uint64(size), // frame number starts with minFrameNumber, so should the read pointer
 		availableFrameChannel: make(chan bool),
@@ -40,8 +40,7 @@ func newReceiveQueue(size int) *receiveQueue {
 	return rq
 }
 
-func (rq *receiveQueue) add(f *frame, sf *subflow) {
-
+func (rq *receiveQueue) add(f *rxFrame, sf *subflow) {
 	select {
 	case rq.availableFrameChannel <- true:
 	default:
@@ -121,7 +120,7 @@ func (rq *receiveQueue) isFull() bool {
 	return true
 }
 
-func (rq *receiveQueue) tryAdd(f *frame) bool {
+func (rq *receiveQueue) tryAdd(f *rxFrame) bool {
 	idx := f.fn % rq.size
 	if rq.buf[idx].bytes == nil {
 		// empty slot

--- a/receivequeue_test.go
+++ b/receivequeue_test.go
@@ -12,7 +12,7 @@ func TestRead(t *testing.T) {
 	fn := uint64(minFrameNumber - 1)
 	addFrame := func(s string) {
 		fn++
-		q.add(&frame{fn: fn, bytes: []byte(s)}, nil)
+		q.add(&rxFrame{fn: fn, bytes: []byte(s)}, nil)
 	}
 	shouldRead := func(s string) {
 		b := make([]byte, 3)
@@ -28,7 +28,7 @@ func TestRead(t *testing.T) {
 	shouldRead("cd")
 	addFrame("abcd")
 	// adding the same frame number again should have no effect
-	q.add(&frame{fn: fn, bytes: []byte("1234")}, nil)
+	q.add(&rxFrame{fn: fn, bytes: []byte("1234")}, nil)
 	shouldRead("abc")
 	shouldRead("d")
 
@@ -65,7 +65,7 @@ func TestRead(t *testing.T) {
 	shouldWaitBeforeRead(delay, "abc")
 
 	// frames can be added out of order
-	q.add(&frame{fn: fn + 2, bytes: []byte("1234")}, nil)
+	q.add(&rxFrame{fn: fn + 2, bytes: []byte("1234")}, nil)
 	time.AfterFunc(delay, func() {
 		addFrame("abcd")
 	})

--- a/receivequeue_test.go
+++ b/receivequeue_test.go
@@ -12,7 +12,7 @@ func TestRead(t *testing.T) {
 	fn := uint64(minFrameNumber - 1)
 	addFrame := func(s string) {
 		fn++
-		q.add(&frame{fn: fn, bytes: []byte(s)})
+		q.add(&frame{fn: fn, bytes: []byte(s)}, nil)
 	}
 	shouldRead := func(s string) {
 		b := make([]byte, 3)
@@ -28,7 +28,7 @@ func TestRead(t *testing.T) {
 	shouldRead("cd")
 	addFrame("abcd")
 	// adding the same frame number again should have no effect
-	q.add(&frame{fn: fn, bytes: []byte("1234")})
+	q.add(&frame{fn: fn, bytes: []byte("1234")}, nil)
 	shouldRead("abc")
 	shouldRead("d")
 
@@ -65,7 +65,7 @@ func TestRead(t *testing.T) {
 	shouldWaitBeforeRead(delay, "abc")
 
 	// frames can be added out of order
-	q.add(&frame{fn: fn + 2, bytes: []byte("1234")})
+	q.add(&frame{fn: fn + 2, bytes: []byte("1234")}, nil)
 	time.AfterFunc(delay, func() {
 		addFrame("abcd")
 	})

--- a/receivequeue_test.go
+++ b/receivequeue_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestRead(t *testing.T) {
-	// does this work? ?
 	q := newReceiveQueue(2)
 	fn := uint64(minFrameNumber - 1)
 	addFrame := func(s string) {

--- a/receivequeue_test.go
+++ b/receivequeue_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestRead(t *testing.T) {
+	// does this work? ?
 	q := newReceiveQueue(2)
 	fn := uint64(minFrameNumber - 1)
 	addFrame := func(s string) {
@@ -31,19 +32,6 @@ func TestRead(t *testing.T) {
 	q.add(&rxFrame{fn: fn, bytes: []byte("1234")}, nil)
 	shouldRead("abc")
 	shouldRead("d")
-
-	addFrame("abc")
-	addFrame("abc")
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		shouldRead("abc")
-	}()
-	start := time.Now()
-	addFrame("abc")
-	assert.InDelta(t, time.Since(start), 50*time.Millisecond, float64(20*time.Millisecond),
-		"when receive queue is full, adding frame should wait for available slot")
-	shouldRead("abc")
-	shouldRead("abc")
 
 	shouldWaitBeforeRead := func(d time.Duration, s string) {
 		start := time.Now()

--- a/subflow.go
+++ b/subflow.go
@@ -272,7 +272,12 @@ func (sf *subflow) getRTT() time.Duration {
 	// up-to-date.
 	var realtime time.Duration
 	sf.muPendingPing.RLock()
-	realtime = time.Since(sf.pendingPing.sentAt)
+	if sf.pendingPing != nil {
+		realtime = time.Since(sf.pendingPing.sentAt)
+	} else {
+		sf.muPendingPing.RUnlock()
+		return recorded
+	}
 	sf.muPendingPing.RUnlock()
 	if realtime > recorded {
 		return realtime

--- a/subflow.go
+++ b/subflow.go
@@ -38,11 +38,12 @@ type subflow struct {
 
 func startSubflow(to string, c net.Conn, mpc *mpConn, clientSide bool, probeStart time.Time, tracker StatsTracker) *subflow {
 	sf := &subflow{
-		to:          to,
-		conn:        c,
-		mpc:         mpc,
-		chClose:     make(chan struct{}),
-		sendQueue:   make(chan *sendFrame, 1),
+		to:        to,
+		conn:      c,
+		mpc:       mpc,
+		chClose:   make(chan struct{}),
+		sendQueue: make(chan *sendFrame, 1),
+		// pendingPing is used for storing the subflow's ping data. Handy since pings are subflow dependent
 		pendingPing: nil,
 		emaRTT:      ema.NewDuration(longRTT, rttAlpha),
 		tracker:     tracker,

--- a/subflow.go
+++ b/subflow.go
@@ -198,7 +198,6 @@ func (sf *subflow) gotACK(fn uint64) {
 		delete(sf.mpc.pendingAckMap, fn)
 		sf.mpc.pendingAckMu.Unlock()
 	} else {
-		log.Errorf("unsolicited ack for frame %d from %s", fn, sf.to)
 		sf.mpc.pendingAckMu.RUnlock()
 		return
 	}

--- a/subflow.go
+++ b/subflow.go
@@ -42,7 +42,7 @@ func startSubflow(to string, c net.Conn, mpc *mpConn, clientSide bool, probeStar
 		conn:        c,
 		mpc:         mpc,
 		chClose:     make(chan struct{}),
-		sendQueue:   make(chan *sendFrame),
+		sendQueue:   make(chan *sendFrame, 1),
 		pendingPing: nil,
 		emaRTT:      ema.NewDuration(longRTT, rttAlpha),
 		tracker:     tracker,

--- a/subflow.go
+++ b/subflow.go
@@ -70,7 +70,7 @@ func startSubflow(to string, c net.Conn, mpc *mpConn, clientSide bool, probeStar
 }
 
 func (sf *subflow) readLoop() (err error) {
-	ch := make(chan *frame)
+	ch := make(chan *rxFrame)
 	r := byteReader{Reader: sf.conn}
 	go sf.readLoopFrames(ch, err, r)
 
@@ -95,7 +95,7 @@ func (sf *subflow) readLoop() (err error) {
 	}
 }
 
-func (sf *subflow) readLoopFrames(ch chan *frame, err error, r byteReader) bool {
+func (sf *subflow) readLoopFrames(ch chan *rxFrame, err error, r byteReader) bool {
 	defer close(ch)
 	for {
 		// The is the core "reactor" where frames are read. The frame format
@@ -135,7 +135,7 @@ func (sf *subflow) readLoopFrames(ch chan *frame, err error, r byteReader) bool 
 			continue
 		}
 
-		ch <- &frame{fn: fn, bytes: buf}
+		ch <- &rxFrame{fn: fn, bytes: buf}
 		sf.tracker.OnRecv(sz)
 		select {
 		case <-sf.chClose:

--- a/subflow.go
+++ b/subflow.go
@@ -226,6 +226,12 @@ func (sf *subflow) sendLoop() {
 }
 
 func (sf *subflow) ack(fn uint64) {
+	if sf == nil {
+		// This should only ever happen in testing.
+		log.Debugf("Nil subflow requested to do an ack! (should only happen on tests)")
+		return
+	}
+
 	select {
 	case <-sf.chClose:
 	case sf.sendQueue <- composeFrame(fn, nil):

--- a/subflow.go
+++ b/subflow.go
@@ -119,7 +119,7 @@ func (sf *subflow) readLoop() (err error) {
 			if frame == nil {
 				return
 			}
-			sf.mpc.recvQueue.add(frame)
+			sf.mpc.recvQueue.add(frame, sf)
 			if !probeTimer.Stop() {
 				<-probeTimer.C
 			}


### PR DESCRIPTION
commit b78f0d757edf6c077acd3301bd7b07dd629bb864 (HEAD -> fix-a-lot, origin/fix-a-lot)
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Wed Nov 3 18:27:01 2021 +0000

    Final snags, mostly fixing quirks attached to tests

commit 0d797bc7404d3ac8ea50c6f364757ec575a3366e
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Wed Nov 3 17:46:00 2021 +0000

    Fix ReceiveQueue tests.
    
    We no longer wait if we have no capacity in a RxQ, this is
    because we assume that the sender will retransmit.

commit 446135c39f559f667b35ae99f7ba83e2cb934aa4
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Wed Nov 3 17:03:35 2021 +0000

    Protect subflow.getRTT() from nil panic race conditions

commit c264cf06c525b2fbf096dabeda19215197784309
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Wed Nov 3 16:38:34 2021 +0000

    Make mpConn.Write() Handle blocking sf.SendQ's and infinate RAM usage
    
    So, mpConn.Write() before this had the ability to consume unlimited
    RAM since stuff could just forever pile up in the ackMaps. This is
    no longer the case, we can only hold 500~ slots in the pendingAckMap.
    *This does not mean* that we can only have 500 things in-flight, this
    instead means that we can only have 500 things that are fully blocked
    from being sent and not acked. This is critical since when you have
    non blocking writes you can easily get slimed by a very eager application
    just infinately putting stuff in the "to be retransmitted" pile.

commit baf00c6148ffe4f0d568662c57d9c7a72589d559
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Wed Nov 3 16:36:44 2021 +0000

    Normalise race conditions on sendFrame.release
    
    Since retransmit loops and what not can call this twice easily,
    during a subflow recovery (aka reading back a blocked SendQ) there
    is no point in error-ing for it. Since we already have protection

commit 890b78aabd0bbc7e97c6dbe845c87c7a6f6f8bbc
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Wed Nov 3 16:36:19 2021 +0000

    Better docs on the use of sf.pendingPing

commit 09dad748c1c0066ebcb7420cc6ac5518564c8166
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Wed Nov 3 16:34:07 2021 +0000

    Enable sendQueue buffering to aid anti-blocking when sf's fail
    
    Otherwise the upstream MPConn Write() can lock up when a
    subflow locks up. This is quite annoying.

commit 674d60326de4555cd38ec5f5da65621caa89faf4
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Wed Nov 3 16:26:40 2021 +0000

    Rename frame to rxFrame, to assist understanding the codebase
    
    This messed with me massively while reading and debugging
    this codebase, so renaming frame to rxFrame signals excactly
    where it's used. In the rx path. Meaning less chaos and terror
    when you are staring at this code in a debugger session

commit ef955ca786593f4a383eebf673c1a9d0fb576c0a
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Wed Nov 3 15:49:19 2021 +0000

    Actually start the retransmitLoop upon newMPConn()

commit ddf49c93fb3047963ba5d03613134ceaea596603
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Tue Nov 2 17:56:29 2021 +0000

    Make mpConn.retransmit avoid sending retansmits down the same sf
    
    Using the previous changes, we can avoid subflows being backed up
    with the same retransmits.
    
    This allows failover from connections that have locked up, but not
    in an application visible way yet (since the SendQ is still buffering)
    
    The `if time.Since(avoidSF.txTime) < time.Second {` is here to overcome
    a possible issue attached with sending data too far in the future
    and the result being silently dropped.
    
    There is no real way to communicate that this has happened (though
    you could hack one in for bettter efficiancy), but for now given
    this almost only ever happens due to a subflow locking up and
    then data being retransmitted too quickyly or in the wrong order.
    
    the time second retransmit window is a good enough way to resolve
    this deadlock
    
    Even if it means that connections will keep being hammered for
    a while

commit 0dccea94e18bf8f448ffd1222cd1558c0955d369
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Tue Nov 2 17:53:23 2021 +0000

    Overhaul of the sending loop.
    
    This new sending loop machineary avoids blocking. This allows
    connections to lock up (or just hit the back of it's TCP SendQ)
    without the rest of the application locking up with it.
    
    This also populates data needed for the retransmission loop
    to avoid retransmissions from being send down the same subflow
    over and over again. Allowing very rapid recovery from a subflow
    failing.

commit fb805a30a403845cc139fc9ea4e5522dc7903211
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Tue Nov 2 17:43:01 2021 +0000

    Split sf.readLoop into two, removing the embedded function
    
    This makes debugging a lot easier. Some other minor changes
    have been applied too, like:
    
    A) Instantly send a out a probe on start. This is helpful
    since otherwise the startup write performance would be poor as the
    system does not know what link has the lowest RTT yet.
    
    B) sf.readLoopFrames now also checks for things that would
    possibly corrupt data downstream, like reading frames that are
    too far in the future for the recvQueue

commit 27d0eae9a82844614e3cca847d7ed66b626998a1
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Tue Nov 2 17:36:24 2021 +0000

    Total overhaul of receiveQueue to be resliant to multipathing
    
    receiveQueue just didnt work very well before this. Bugs that
    have been fixed are:
    
    A) If a frame was sent that was over 4096 (rq.size) frame ahead
    of what the reader was reading. Silent data corruption would happen.
    
    B) Deadlocks were common due to nuances on how sync.coord works. If
    there just so happened not to be something waiting on a signal. It
    would be lost, but then the source of signals would also stall, since
    they need each other to signal to eachother.

commit 608255a85743d64a928d2c62e044b90cc9486245
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Tue Nov 2 17:03:57 2021 +0000

    Move retransmits to mostly driven by a retransmit loop
    
    This re-complexs a lot of things. But also allows for
    nice things like retransmitting "dead" frames in-order.
    
    Since the receiveQueue on the other side only has 4096 slots
    if you don't transmit them in order, then you may have
    to send them again because the frames got dropped due
    to being too far in the future.

commit 90df7f91aaba187711776560f1549a9099fd1edb
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Tue Nov 2 16:23:52 2021 +0000

    Track more data in the pendingAck for retransmit logic

commit dbec0a45df5a32d899706117cb5cc038c2498bb0
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Tue Nov 2 16:16:56 2021 +0000

    Remove error attached to unsolicited ack's
    
    Since it is valid to get a old-ack if one of the subflow locks
    up and then comes back a few mins later.

commit 6916f598348fe5471cbdfa54ab44bb0f9f416de9
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Tue Nov 2 16:15:35 2021 +0000

    Move ack tracking to be a connection level concept
    
    Since ack-s can come in from any subflow now. So we need to be
    tracking them globally rather than per subflow.
    
    Without this, we will explode/hang if we get a ack from a retransmit
    or a load balenced ack

commit a7f04d5c75d82202c1f5fb9a6245829f5f9ff41d
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Thu Oct 21 14:30:15 2021 +0100

    Allow multipath to use all available connections for bonding
    
    Right now it would only use sortedSubflows(), and that picked
    the lowest RTT, it would only follow on to the next connection

---

- [X] Do the tests pass? Consistently?
- ? Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [ ] Can it be QA’d in staging or something like staging?
- [X] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [X] Do we know how we’re going to deploy this?
- [X] Are we clear on what the support and maintenance impact is?
- [ ] Did you create new documentation? Is it accessible and in the right place?
- [ ] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?