### PR TITLE
Improvements from bondcat/bgp.tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,10 @@ See docs in [multipath.go](multipath.go) for details.
 This code is used in https://github.com/benjojo/bondcat, and hat's off to [@benjojo](https://github.com/benjojo) for implementing [many fixes](https://github.com/benjojo/bondcat/tree/main/multipath).
 
 At a high level, this concept is built on a similar notion as [MultiPath TCP](https://www.multipath-tcp.org/), but our "multipath" works at a higher level in the stack where it implements different protocols that each have their own subflow but are all running on their own TCP or reliable UDP transports underneath.
+
+---
+## Operational notes
+
+When setting up a multipath socket, you should only give it dailers that you are reasonably sure will work. Multipath will only use one dailer at a time to setup a connection. If the first, second, third dialer times out, then connection setup will take that long.
+
+There is a mitigation for this, in where a dialer can only take 2 seconds for setup, but that still may not provide a very usable user experiance for interactive applications. You may want to run some kind of multiplexer on top of the multipath connection to avoid dailing this over and over again.

--- a/dialer.go
+++ b/dialer.go
@@ -86,63 +86,61 @@ func NewDialer(dest string, dialers []Dialer) Dialer {
 	return d
 }
 
+func (mpd *mpDialer) dialOne(d *subflowDialer, cid connectionID, bc *mpConn, ctx context.Context) (connectionID, bool, *mpConn) {
+	conn, err := d.DialContext(ctx)
+	if err != nil {
+		log.Errorf("failed to dial %s: %v", d.Label(), err)
+		return zeroCID, false, bc
+	}
+	probeStart := time.Now()
+	newCID, err := mpd.handshake(conn, cid)
+	if err != nil {
+		log.Errorf("failed to handshake %s, continuing: %v", d.Label(), err)
+		conn.Close()
+		return zeroCID, false, bc
+	}
+	if cid == zeroCID {
+		bc = newMPConn(newCID, conn.RemoteAddr())
+		go func() {
+			for {
+				time.Sleep(time.Second)
+				bc.pendingAckMu.RLock()
+				oldest := time.Duration(0)
+				oldestFN := uint64(0)
+				for fn, frame := range bc.pendingAckMap {
+					if time.Since(frame.sentAt) > oldest {
+						oldest = time.Since(frame.sentAt)
+						oldestFN = fn
+					}
+				}
+				bc.pendingAckMu.RUnlock()
+				if oldest > time.Second {
+					log.Debugf("Frame %d has not been acked for %v\n", oldestFN, oldest)
+				}
+			}
+		}()
+	}
+	bc.add(fmt.Sprintf("%x(%s)", newCID, d.label), conn, true, probeStart, d)
+	return newCID, true, bc
+}
+
 // DialContext dials the addr using all dialers and returns a connection
 // contains subflows from whatever dialers available.
 func (mpd *mpDialer) DialContext(ctx context.Context) (net.Conn, error) {
 	var bc *mpConn
-	dialOne := func(d *subflowDialer, cid connectionID) (connectionID, bool) {
-		conn, err := d.DialContext(ctx)
-		if err != nil {
-			log.Errorf("failed to dial %s: %v", d.Label(), err)
-			return zeroCID, false
-		}
-		probeStart := time.Now()
-		newCID, err := mpd.handshake(conn, cid)
-		if err != nil {
-			log.Errorf("failed to handshake %s, continuing: %v", d.Label(), err)
-			conn.Close()
-			return zeroCID, false
-		}
-		if cid == zeroCID {
-			bc = newMPConn(newCID, conn.RemoteAddr())
-			go func() {
-				for {
-					time.Sleep(time.Second)
-					select {
-					case <-ctx.Done():
-						return
-					default:
-						bc.pendingAckMu.RLock()
-						oldest := time.Duration(0)
-						oldestFN := uint64(0)
-						for fn, frame := range bc.pendingAckMap {
-							if time.Since(frame.sentAt) > oldest {
-								oldest = time.Since(frame.sentAt)
-								oldestFN = fn
-							}
-						}
-						bc.pendingAckMu.RUnlock()
-						if oldest > time.Second {
-							log.Debugf("Frame %d has not been acked for %v\n", oldestFN, oldest)
-						}
-					}
-				}
-			}()
-		}
-		bc.add(fmt.Sprintf("%x(%s)", newCID, d.label), conn, true, probeStart, d)
-		return newCID, true
-	}
 	dialers := mpd.sorted()
 	for i, d := range dialers {
 		// dial the first connection with zero connection ID
-		cid, ok := dialOne(d, zeroCID)
+		dialctx, dialcancel := context.WithTimeout(ctx, time.Second*2)
+		defer dialcancel()
+		cid, ok, bc := mpd.dialOne(d, zeroCID, bc, dialctx)
 		if !ok {
 			continue
 		}
 		if i < len(dialers)-1 {
 			// dial the rest in parallel with server assigned connection ID
 			for _, d := range dialers[i+1:] {
-				go dialOne(d, cid)
+				go mpd.dialOne(d, cid, bc, ctx)
 			}
 		}
 		return bc, nil

--- a/multipath.go
+++ b/multipath.go
@@ -10,9 +10,9 @@
 // first subflow, the client sends an all-zero connnection ID (CID) and the
 // server sends the assigned CID back. Subsequent subflows use the same CID.
 //
-//       ----------------------------------------------------
-//      |  version(1)  |  cid(16)  |  frames (...)  |
-//       ----------------------------------------------------
+//	 ----------------------------------------------------
+//	|  version(1)  |  cid(16)  |  frames (...)  |
+//	 ----------------------------------------------------
 //
 // There are two types of frames. Data frame carries application data while ack
 // frame carries acknowledgement to the frame just received. When one data
@@ -21,28 +21,29 @@
 // variable-length integer encoding as described here:
 // https://tools.ietf.org/html/draft-ietf-quic-transport-29#section-16
 //
-//       --------------------------------------------------------
-//      |  payload size(1-8)  |  frame number (1-8)  |  payload  |
-//       --------------------------------------------------------
+//	      --------------------------------------------------------
+//	     |  payload size(1-8)  |  frame number (1-8)  |  payload  |
+//	      --------------------------------------------------------
 //
-//       ---------------------------------------
-//      |  00000000  |  ack frame number (1-8)  |
-//       ---------------------------------------
+//		 ---------------------------------------
+//		|  00000000  |  ack frame number (1-8)  |
+//		 ---------------------------------------
 //
 // Ack frames with frame number < 10 are reserved for control. For now only 0
 // and 1 are used, for ping and pong frame respectively. They are for updating
 // RTT on inactive subflows and detecting recovered subflows.
 //
 // Ping frame:
-//       -------------------------
-//      |  00000000  |  00000000  |
-//       -------------------------
+//
+//	 -------------------------
+//	|  00000000  |  00000000  |
+//	 -------------------------
 //
 // Pong frame:
-//       -------------------------
-//      |  00000000  |  00000001  |
-//       -------------------------
 //
+//	 -------------------------
+//	|  00000000  |  00000001  |
+//	 -------------------------
 package multipath
 
 import (


### PR DESCRIPTION
Attached are some of the improvements that have been put into bgp.tools and bondcat

commit 40461c6bdb14314fab637ed35f3353184db4ae67 (HEAD -> bgptools-improvements, fork/bgptools-improvements, main)
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Sat Jun 10 11:38:09 2023 +0100

    Add operational notes

commit e62f031243879a61cc2d41ddec577b72ddccfd1b
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Sat Jun 10 11:34:45 2023 +0100

    Add timeouts to the inital subflow dialing
    
    Otherwise if you give multipath a bunch of dialers, with some
    of them not working (in the timeout failure case) the multipath
    package will not setup a connection in a timely manner, with this
    it will only wait 2 seconds for a subflow to come up online before
    moving on to the next one

commit 55dbf5d00254c6c46a999379e22fd7be5128ceea
Author: Ben Cartwright-Cox <ben@benjojo.co.uk>
Date:   Sat Jun 10 11:31:52 2023 +0100

    Fix subtle race condition resulting in "Corrupted Buffer detected"
    
    This happened when some subflows are a lot higher latency than the
    others, this causes a retransmit to reset the state of the RXQ, and
    then cause the buffer slice to be reset. causing a buffer corruption
    error to be raised.
    
    This bug was detected with bgp.tools clients running in South Africa

---

55dbf5d00254c6c46a999379e22fd7be5128ceea is actually quite critical, as it will impact almost all connection under high latency conditions, and is treated as a fatal error.

e62f031243879a61cc2d41ddec577b72ddccfd1b Provides a much better UX for most applications, bgp.tools uses this one quite critically as a lot of the dailers provided to the library will not work. 